### PR TITLE
bugfix round time zero crash / break timer not depleting 

### DIFF
--- a/Shared/Models/MobSession.swift
+++ b/Shared/Models/MobSession.swift
@@ -31,7 +31,7 @@ struct Configuration: Identifiable {
     var angle: Double
     
     var formattedValue: Int {
-        (Int(progress * Double(maxValue)) / 60)
+        (Int(progress * Double(maxValue)) / 60) + 1
     }
     
     init(value: Int, maxValue: Int, isTimeValue: Bool, label: String, color: String) {

--- a/Shared/ViewModel/MobSessionManager.swift
+++ b/Shared/ViewModel/MobSessionManager.swift
@@ -75,6 +75,7 @@ extension MobSessionManager {
         isOnBreak = false
         currentRotationNumber = 1
         mobTimer.timeRemaining = mobTimer.rotationLength.value
+        mobTimer.rotationLength.value = mobTimer.rotationLength.value
     }
     
     private func setUpNextRound() {
@@ -87,6 +88,7 @@ extension MobSessionManager {
     private func startBreak() {
         isOnBreak = true
         mobTimer.timeRemaining = session.breakLengthInSeconds.value
+        mobTimer.rotationLength.value = session.breakLengthInSeconds.value
         startTimer()
     }
 


### PR DESCRIPTION
- 0 round length no longer breaks the app, 0 can't be selected and range of circle selectors is 1...maxValue
- Fixed bug of timer not depleting correctly during break
