### PR TITLE
bugfix/settings view team member list cutoff

### DIFF
--- a/Shared/CircleSelector.swift
+++ b/Shared/CircleSelector.swift
@@ -17,7 +17,7 @@ struct CircleSelector: View {
                 .font(.title2)
             ZStack {
                 Circle()
-                    .frame(width: Constants.circleSize, height: Constants.circleSize)
+                    .frame(maxWidth: Constants.circleSize, maxHeight: Constants.circleSize)
                     .foregroundColor(.mobGray)
                 
                 ProgressCircle(progress: configuration.progress, color: Color(configuration.color))

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct Constants {
-    static let circleSize = UIScreen.main.bounds.width * 0.54
+    static let circleSize = UIScreen.main.bounds.height * 0.21
     static let lineWidth: CGFloat = 25.0
     static let secondsPerMinute = 60
     static let degreesInACircle = 360.0

--- a/Shared/Constants.swift
+++ b/Shared/Constants.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct Constants {
-    static let circleSize = UIScreen.main.bounds.width - 120
+    static let circleSize = UIScreen.main.bounds.width * 0.54
     static let lineWidth: CGFloat = 25.0
     static let secondsPerMinute = 60
     static let degreesInACircle = 360.0

--- a/Shared/Views/Components/ProgressCircle.swift
+++ b/Shared/Views/Components/ProgressCircle.swift
@@ -15,7 +15,7 @@ struct ProgressCircle: View {
         Circle()
             .trim(from: 0, to: progress)
             .stroke(color, style: StrokeStyle(lineWidth: Constants.lineWidth, lineCap: .round))
-            .frame(width: Constants.circleSize, height: Constants.circleSize)
+            .frame(maxWidth: Constants.circleSize, maxHeight: Constants.circleSize)
             .rotationEffect(.init(degrees: -90))
     }
 }

--- a/Shared/Views/ConfigureSessionView.swift
+++ b/Shared/Views/ConfigureSessionView.swift
@@ -16,9 +16,7 @@ struct ConfigureSessionView: View {
             CircleSelector(configuration: $vm.session.numberOfRotationsBetweenBreaks)
             CircleSelector(configuration: $vm.session.breakLengthInSeconds)
         }
-        .frame(minHeight: UIScreen.main.bounds.height * 0.42)
         .tabViewStyle(.page(indexDisplayMode: .always))
-        .padding()
     }
 }
 

--- a/Shared/Views/MobSessionView/MobSessionView.swift
+++ b/Shared/Views/MobSessionView/MobSessionView.swift
@@ -37,7 +37,6 @@ struct MobSessionView: View {
                     RoundedRectangleButton(label: "End Mobbing Session", color: .mobRedButtonBG) {
                         showingEndSessionAlert = true
                     }
-                    .padding()
                 }
             }
             .toolbar {

--- a/Shared/Views/MobSessionView/MobSessionView.swift
+++ b/Shared/Views/MobSessionView/MobSessionView.swift
@@ -30,14 +30,18 @@ struct MobSessionView: View {
                     }
                 }
                 
-                TeamMemberList()
-                    .environment(\.editMode, $editMode)
-                
-                if vm.isEditing {
-                    RoundedRectangleButton(label: "End Mobbing Session", color: .mobRedButtonBG) {
-                        showingEndSessionAlert = true
+                VStack {
+                    TeamMemberList()
+                        .environment(\.editMode, $editMode)
+                    
+                    if vm.isEditing {
+                        RoundedRectangleButton(label: "End Mobbing Session", color: .mobRedButtonBG) {
+                            showingEndSessionAlert = true
+                        }
                     }
                 }
+                .frame(maxHeight: UIScreen.main.bounds.height * 0.4)
+                
             }
             .toolbar {
                 logo

--- a/Shared/Views/Timer/ActiveTimerView.swift
+++ b/Shared/Views/Timer/ActiveTimerView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct ActiveTimerView: View {
     @EnvironmentObject var vm: MobSessionManager
-    @State private var size = UIScreen.main.bounds.width - 120
 
     let lineWidth: CGFloat = 25.0
     
@@ -18,7 +17,8 @@ struct ActiveTimerView: View {
 
             ZStack {
                 Circle()
-                    .frame(width: size, height: size)
+                    .frame(width: Constants.circleSize, height: Constants.circleSize)
+
                     .foregroundColor(.mobGray)
                 
                 ProgressCircle(progress: vm.mobTimer.timerProgress, color: vm.mobTimer.color)

--- a/Shared/Views/Timer/ActiveTimerView.swift
+++ b/Shared/Views/Timer/ActiveTimerView.swift
@@ -17,7 +17,7 @@ struct ActiveTimerView: View {
 
             ZStack {
                 Circle()
-                    .frame(width: Constants.circleSize, height: Constants.circleSize)
+                    .frame(maxWidth: Constants.circleSize, maxHeight: Constants.circleSize)
 
                     .foregroundColor(.mobGray)
                 
@@ -37,7 +37,7 @@ struct ActiveTimerView: View {
                     Text("\(vm.timerText)")
                         .font(
                         .largeTitle)
-                        .padding()
+                        //.padding()
                    
                     
                     if !vm.isOnBreak {

--- a/Shared/Views/Timer/ActiveTimerView.swift
+++ b/Shared/Views/Timer/ActiveTimerView.swift
@@ -18,7 +18,6 @@ struct ActiveTimerView: View {
             ZStack {
                 Circle()
                     .frame(maxWidth: Constants.circleSize, maxHeight: Constants.circleSize)
-
                     .foregroundColor(.mobGray)
                 
                 ProgressCircle(progress: vm.mobTimer.timerProgress, color: vm.mobTimer.color)
@@ -37,8 +36,6 @@ struct ActiveTimerView: View {
                     Text("\(vm.timerText)")
                         .font(
                         .largeTitle)
-                        //.padding()
-                   
                     
                     if !vm.isOnBreak {
                         Button(action: {

--- a/Shared/Views/Timer/InactiveTimerView.swift
+++ b/Shared/Views/Timer/InactiveTimerView.swift
@@ -14,7 +14,7 @@ struct InactiveTimerView: View {
         ZStack {
             Circle()
                 .foregroundColor(vm.isOnBreak ? .mobOrangeButtonBG : .mobGreenButtonBG)
-                .frame(width: Constants.circleSize, height: Constants.circleSize)
+                .frame(maxWidth: Constants.circleSize, maxHeight: Constants.circleSize)
 
                 .padding()
                 .animation(.default, value: vm.isOnBreak)
@@ -34,7 +34,7 @@ struct InactiveTimerView: View {
                 }
                 
                 Text(vm.timerText)
-                    .padding()
+                    //.padding()
                 
                 if !vm.isOnBreak {
                     Button(action: {

--- a/Shared/Views/Timer/InactiveTimerView.swift
+++ b/Shared/Views/Timer/InactiveTimerView.swift
@@ -14,6 +14,8 @@ struct InactiveTimerView: View {
         ZStack {
             Circle()
                 .foregroundColor(vm.isOnBreak ? .mobOrangeButtonBG : .mobGreenButtonBG)
+                .frame(width: Constants.circleSize, height: Constants.circleSize)
+
                 .padding()
                 .animation(.default, value: vm.isOnBreak)
                 .animation(.default, value: vm.mobTimer.isTimerRunning)

--- a/Shared/Views/Timer/InactiveTimerView.swift
+++ b/Shared/Views/Timer/InactiveTimerView.swift
@@ -34,7 +34,6 @@ struct InactiveTimerView: View {
                 }
                 
                 Text(vm.timerText)
-                    //.padding()
                 
                 if !vm.isOnBreak {
                     Button(action: {


### PR DESCRIPTION
- Messed with UI. Made overall timer circle a bit smaller, appears to be fitting team better on iPhone 11
- Circle is smaller, but visible in most regular text sizes. Team member view is more visible
