### PR TITLE
bugfix/make disabled settings more opaque

### DIFF
--- a/Shared/ViewModel/MobSessionManager.swift
+++ b/Shared/ViewModel/MobSessionManager.swift
@@ -201,6 +201,7 @@ extension MobSessionManager {
                 
                 mobTimer.timeRemaining = mobTimer.timeRemaining - deltaTime < 0 ? 0 : mobTimer.timeRemaining - deltaTime
                 startTimer()
+                self.movedToBackgroundDate = nil
             }
         }
         

--- a/Shared/ViewModel/MobSessionManager.swift
+++ b/Shared/ViewModel/MobSessionManager.swift
@@ -15,7 +15,11 @@ class MobSessionManager: ObservableObject {
     @Published var currentRotationNumber = 1
     @Published var isOnBreak = false
     @Published var movedToBackgroundDate: Date?
-    @Published var isKeyboardPresented = false
+    @Published var isKeyboardPresented = false {
+        didSet {
+            print("Is Keyboard presented: \(isKeyboardPresented)")
+        }
+    }
 
     var numberOfRoundsBeforeBreak: Int {
         session.numberOfRotationsBetweenBreaks.value / 60

--- a/Shared/ViewModel/MobSessionManager.swift
+++ b/Shared/ViewModel/MobSessionManager.swift
@@ -137,6 +137,7 @@ extension MobSessionManager {
         
         if mobTimer.isTimerRunning && !isTeamValid {
             resetTimer()
+            cancelLocalNotification()
         }
     }
     
@@ -151,6 +152,7 @@ extension MobSessionManager {
     func timerTapped() {
         if mobTimer.isTimerRunning {
             resetTimer()
+            cancelLocalNotification()
         } else {
             startTimer()
             scheduleLocalNotification()
@@ -167,7 +169,6 @@ extension MobSessionManager {
                 }
             }
         }
-        
     }
 
     private func resetTimer() {
@@ -179,6 +180,7 @@ extension MobSessionManager {
 // MARK: Timer End Notification
 extension MobSessionManager {
     static let timerEndNotification = "timerEndNotification"
+    
     func requestNotificationPermission() {
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge , .sound]) { success, error in
             if success {
@@ -191,8 +193,11 @@ extension MobSessionManager {
                       
     func movedToBackground() {
         print("Moving to the background")
-        movedToBackgroundDate = Date()
-        resetTimer()
+        
+        if mobTimer.isTimerRunning {
+            movedToBackgroundDate = Date()
+            resetTimer()
+        }
     }
     
     func movingToForeGround() {
@@ -214,7 +219,7 @@ extension MobSessionManager {
     
     func applicationTerminating() {
         print("App terminating")
-        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [Self.timerEndNotification])
+        cancelLocalNotification()
     }
     
     func scheduleLocalNotification() {
@@ -226,5 +231,9 @@ extension MobSessionManager {
         let request = UNNotificationRequest(identifier: Self.timerEndNotification, content: content, trigger: trigger)
         
         UNUserNotificationCenter.current().add(request)
+    }
+    
+    func cancelLocalNotification() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [Self.timerEndNotification])
     }
 }

--- a/Shared/Views/Timer/InactiveTimerView.swift
+++ b/Shared/Views/Timer/InactiveTimerView.swift
@@ -45,8 +45,14 @@ struct InactiveTimerView: View {
                     .disabled(!vm.isTeamValid)
                 }
             }
+            .opacity(vm.isTeamValid ? 1 : 0.5)
             .font(.largeTitle)
             .foregroundColor(.white)
+            
+            if !vm.isTeamValid {
+                Text("You need at least two Team Members")
+                    .foregroundColor(.mobRed)
+            }
         }
     }
 }


### PR DESCRIPTION
- Fixed bug where coming back to foreground second time after going to background was screwing up the timer
- Made inactive timer text opaque when team is invalid. Also added warning to add more team members if team is invalid
- Removed local notification when timer is paused / team is invalid. Only captures move to background date and resets timer if timer is currently running
